### PR TITLE
feat: add thinking mode support for GLM-4.5+ models

### DIFF
--- a/src/zhipu-chat-language-model.ts
+++ b/src/zhipu-chat-language-model.ts
@@ -61,8 +61,13 @@ export class ZhipuChatLanguageModel implements LanguageModelV2 {
     this.settings = settings;
     this.config = config;
     this.config.isMultiModel = this.modelId.includes("v");
+    // Model is a reasoning model if:
+    // 1. Model ID contains "z" or "thinking" (dedicated reasoning models)
+    // 2. Thinking mode is explicitly enabled via settings (GLM-4.5+ with thinking)
     this.config.isReasoningModel =
-      this.modelId.includes("z") || this.modelId.includes("thinking");
+      this.modelId.includes("z") ||
+      this.modelId.includes("thinking") ||
+      settings.thinking?.type === "enabled";
   }
 
   /**
@@ -202,6 +207,16 @@ export class ZhipuChatLanguageModel implements LanguageModelV2 {
       user_id: this.settings.userId,
       do_sample: this.settings.doSample,
       request_id: this.settings.requestId,
+
+      // thinking mode for GLM-4.5+ models:
+      thinking: this.settings.thinking
+        ? {
+            type: this.settings.thinking.type,
+            ...(this.settings.thinking.clearThinking !== undefined && {
+              clear_thinking: this.settings.thinking.clearThinking,
+            }),
+          }
+        : undefined,
 
       // standardized settings:
       max_tokens: maxOutputTokens,

--- a/src/zhipu-chat-settings.ts
+++ b/src/zhipu-chat-settings.ts
@@ -23,6 +23,25 @@ export type ZhipuChatModelId =
   | "glm-4.1v-thinking-flashx"
   | (string & {});
 
+/**
+ * Thinking mode configuration for GLM-4.5+ models.
+ * Enables deep reasoning capabilities for complex tasks.
+ */
+export interface ZhipuThinkingConfig {
+  /**
+   * Enable or disable thinking mode.
+   * - "enabled": Model will use deep reasoning before responding
+   * - "disabled": Standard response without explicit reasoning
+   */
+  type: "enabled" | "disabled";
+  /**
+   * Whether to clear thinking content from previous turns.
+   * When true, previous reasoning is not retained in context.
+   * @default false
+   */
+  clearThinking?: boolean;
+}
+
 export interface ZhipuChatSettings {
   /**
    * The unique ID of the end user, helps the platform intervene in illegal activities, generate illegal or improper information, or other abuse by the end user.
@@ -38,4 +57,12 @@ export interface ZhipuChatSettings {
    * When do_sample is true, sampling strategy is enabled, when do_sample is false, the sampling strategy temperature, top_p will not take effect
    */
   doSample?: boolean;
+  /**
+   * Enable thinking/reasoning mode for GLM-4.5+ models.
+   * When enabled, the model will perform deep reasoning before responding,
+   * which improves performance on complex tasks like coding and multi-step reasoning.
+   *
+   * @see https://docs.z.ai/guides/llm/glm-4.7
+   */
+  thinking?: ZhipuThinkingConfig;
 }


### PR DESCRIPTION
## Summary
Add support for the `thinking` parameter which enables deep reasoning capabilities for GLM-4.5 series and newer models (GLM-4.5, GLM-4.6, GLM-4.7).

## Changes
- Add `ZhipuThinkingConfig` interface with `type` and `clearThinking` options
- Add `thinking` setting to `ZhipuChatSettings`
- Pass `thinking` parameter to API in `baseArgs`
- Detect reasoning mode when thinking is explicitly enabled via settings

## Usage

```typescript
import { zhipu } from 'zhipu-ai-provider';
import { generateText } from 'ai';

const { text } = await generateText({
  model: zhipu('glm-4.7', {
    thinking: { type: 'enabled' }
  }),
  prompt: 'Solve this complex coding problem...',
});
```

## API Reference
- https://docs.z.ai/guides/llm/glm-4.7
- https://docs.z.ai/api-reference/llm/chat-completion

The thinking mode enables:
- **Interleaved Thinking**: Thinks before each answer/tool call
- **Preserved Thinking**: Maintains reasoning context across turns
- **Turn-level Thinking**: Control reasoning per turn