### PR TITLE
Fix non-vision warning for mixed prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const { text } = await generateText({
   prompt: 'Why is the sky blue?',
 });
 
-console.log(result)
+console.log(text)
 ```
 
 To disable thinking for hybrid models like `glm-5`, set `thinking.type` to `disabled` either in the model options or in `providerOptions.zhipu`:
@@ -166,4 +166,4 @@ console.log(providerMetadata.zhipu.images[0].url)
 
 ## Maintainer Examples
 
-Runnable maintainer-facing demo scripts live in [examples/README.md](/Users/cxiang/Projects/vercel-ai-provider-zhipu/examples/README.md). They cover text generation, streaming, reasoning, tool calls, vision prompts, embeddings, and image generation.
+Runnable maintainer-facing demo scripts live in [examples/README.md](examples/README.md). They cover text generation, streaming, reasoning, tool calls, vision prompts, embeddings, and image generation.

--- a/src/zhipu-chat-language-model.test.ts
+++ b/src/zhipu-chat-language-model.test.ts
@@ -241,6 +241,32 @@ describe("doGenerate", () => {
     );
   });
 
+  it("should warn when non-vision models receive non-text user parts", async () => {
+    prepareJsonResponse({ content: "" });
+
+    const result = await model.doGenerate({
+      prompt: [
+        { role: "system", content: "You are concise." },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Describe this image" },
+            {
+              type: "file",
+              data: new URL("https://example.com/image.png"),
+              mediaType: "image/png",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.warnings).toContainEqual({
+      type: "other",
+      message: "Non-vision models does not support message parts",
+    });
+  });
+
   it("should pass providerOptions.zhipu and override base args", async () => {
     prepareJsonResponse({ content: "" });
 

--- a/src/zhipu-chat-language-model.ts
+++ b/src/zhipu-chat-language-model.ts
@@ -91,10 +91,10 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
 
     if (
       !this.config.isMultiModel &&
-      prompt.every(
+      prompt.some(
         (msg) =>
           msg.role === "user" &&
-          !msg.content.every((part) => part.type === "text"),
+          msg.content.some((part) => part.type !== "text"),
       )
     ) {
       warnings.push({


### PR DESCRIPTION
## Summary
- warn when non-vision chat models receive any non-text user part, including prompts that also contain system messages
- add regression coverage for a system-plus-image prompt
- fix the README text-generation log statement and examples link

## Validation
- pnpm test:node
- pnpm test:edge
- pnpm type-check
- pnpm lint
- pnpm build

Note: `pnpm prettier-check` currently exits with `sh: prettier: command not found` in this checkout because the script references Prettier but the package is not installed; I left dependency and lockfile changes out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation for non-vision models. The provider now correctly detects and warns when unsupported content types (such as images) are provided to language models without vision capabilities.

* **Documentation**
  * Updated README code examples to reflect current usage patterns.
  * Corrected maintainer documentation links to use relative file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->