### PR TITLE
feat: support Zhipu reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,28 @@ const { text } = await generateText({
 });
 ```
 
+For GLM-5.2 and newer models, use `reasoningEffort` to control how much
+reasoning the model applies. It accepts `max`, `xhigh`, `high`, `medium`,
+`low`, `minimal`, and `none`:
+
+```ts
+const { text } = await generateText({
+  model: zhipu('glm-5.2'),
+  prompt: 'Design a resilient recommendation system.',
+  providerOptions: {
+    zhipu: {
+      thinking: { type: 'enabled' },
+      reasoningEffort: 'high',
+    },
+  },
+});
+```
+
+The provider forwards `reasoningEffort` for any model ID, so future Z.ai
+models do not require a provider update. It warns, without blocking the
+request, when a recognized GLM-5.1-or-earlier model is used because Z.ai will
+likely ignore `reasoning_effort` for those models.
+
 Only function tools are supported. Provider-defined tools are not currently implemented.
 
 ## Embedding Example

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,7 @@ export ZHIPU_PROVIDER=zai
 export ZHIPU_BASE_URL=https://open.bigmodel.cn/api/paas/v4
 export ZHIPU_TEXT_MODEL=glm-4-flash
 export ZHIPU_REASONING_MODEL=glm-4.5
+export ZHIPU_REASONING_EFFORT_MODEL=glm-5.2
 export ZHIPU_VISION_MODEL=glm-4.1v-thinking-flash
 export ZHIPU_EMBEDDING_MODEL=embedding-3
 export ZHIPU_IMAGE_MODEL=glm-image
@@ -35,6 +36,7 @@ export EXAMPLE_IMAGE_URL=https://upload.wikimedia.org/wikipedia/commons/3/3f/Fro
 pnpm example:generate-text
 pnpm example:stream-text
 pnpm example:generate-text-reasoning
+pnpm example:generate-text-reasoning-effort
 pnpm example:generate-text-tool-call
 pnpm example:generate-text-with-images
 pnpm example:embed
@@ -46,6 +48,7 @@ pnpm example:generate-image
 - `generate-text.mjs`: basic text generation
 - `stream-text.mjs`: streamed text output
 - `generate-text-reasoning.mjs`: reasoning-enabled text generation without tools
+- `generate-text-reasoning-effort.mjs`: GLM-5.2 reasoning-effort control through provider options
 - `generate-text-tool-call.mjs`: reasoning plus function tool calls
 - `generate-text-with-images.mjs`: multimodal prompt with an image URL
 - `embed.mjs`: text embeddings

--- a/examples/generate-text-reasoning-effort.mjs
+++ b/examples/generate-text-reasoning-effort.mjs
@@ -1,0 +1,24 @@
+import process from "node:process";
+import { generateText } from "ai";
+import { getProvider, printWarnings, section } from "./_shared.mjs";
+
+const provider = getProvider();
+const modelId = process.env.ZHIPU_REASONING_EFFORT_MODEL ?? "glm-5.2";
+
+const result = await generateText({
+  model: provider(modelId),
+  prompt:
+    "Design a resilient recommendation system, then summarize the tradeoffs in a compact checklist.",
+  providerOptions: {
+    zhipu: {
+      thinking: { type: "enabled" },
+      reasoningEffort: "high",
+    },
+  },
+});
+
+section("Text");
+console.log(result.text);
+section("Reasoning");
+console.log(result.reasoningText);
+printWarnings(result.warnings);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "example:generate-text": "node examples/generate-text.mjs",
     "example:stream-text": "node examples/stream-text.mjs",
     "example:generate-text-reasoning": "node examples/generate-text-reasoning.mjs",
+    "example:generate-text-reasoning-effort": "node examples/generate-text-reasoning-effort.mjs",
     "example:generate-text-tool-call": "node examples/generate-text-tool-call.mjs",
     "example:generate-text-with-images": "node examples/generate-text-with-images.mjs",
     "example:embed": "node examples/embed.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,8 @@
 export { createZhipu, zhipu, zai } from "./zhipu-provider";
 export type { ZhipuProvider, ZhipuProviderSettings } from "./zhipu-provider";
+export type {
+  ZhipuChatModelId,
+  ZhipuChatSettings,
+  ZhipuReasoningEffort,
+  ZhipuThinkingConfig,
+} from "./zhipu-chat-settings";

--- a/src/zhipu-chat-language-model.test.ts
+++ b/src/zhipu-chat-language-model.test.ts
@@ -354,7 +354,7 @@ describe("doGenerate", () => {
     expect(body.reasoning_effort).toBe("minimal");
   });
 
-  it.each(["glm-5.1", "glm-5", "glm-4.7-flash"])(
+  it.each(["glm-5.1", "glm-5", "glm-4.7-flash", "glm-4.6v", "glm-5v-turbo"])(
     "should warn when reasoning effort is used with %s",
     async (modelId) => {
       prepareJsonResponse({ content: "" });

--- a/src/zhipu-chat-language-model.test.ts
+++ b/src/zhipu-chat-language-model.test.ts
@@ -12,6 +12,7 @@ type ZhipuRequestBody = {
   tool_choice?: string;
   stream?: boolean;
   response_format?: { type: string };
+  reasoning_effort?: string;
 };
 
 const TEST_PROMPT = [
@@ -291,6 +292,131 @@ describe("doGenerate", () => {
     expect(body.user_id).toBe("override-user-id");
     expect(body.temperature).toBe(0.8);
   });
+
+  it.each([
+    "max",
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+    "minimal",
+    "none",
+  ] as const)("should map %s reasoning effort to the API request", async (reasoningEffort) => {
+    prepareJsonResponse({ content: "" });
+
+    await provider
+      .chat("glm-5.2", { reasoningEffort })
+      .doGenerate({ prompt: TEST_PROMPT });
+
+    const calls =
+      server.urls["https://open.bigmodel.cn/api/paas/v4/chat/completions"]
+        .calls;
+    const body = calls[calls.length - 1].requestBodyJson as ZhipuRequestBody;
+    expect(body.reasoning_effort).toBe(reasoningEffort);
+  });
+
+  it("should prefer request-level reasoningEffort and omit its camel-case form", async () => {
+    prepareJsonResponse({ content: "" });
+
+    await provider
+      .chat("glm-5.2", { reasoningEffort: "low" })
+      .doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          zhipu: { reasoningEffort: "high" },
+        },
+      });
+
+    const calls =
+      server.urls["https://open.bigmodel.cn/api/paas/v4/chat/completions"]
+        .calls;
+    const body = calls[calls.length - 1].requestBodyJson as ZhipuRequestBody;
+    expect(body.reasoning_effort).toBe("high");
+    expect(body).not.toHaveProperty("reasoningEffort");
+  });
+
+  it("should preserve raw reasoning_effort provider-option passthrough", async () => {
+    prepareJsonResponse({ content: "" });
+
+    await provider
+      .chat("glm-5.2", { reasoningEffort: "low" })
+      .doGenerate({
+        prompt: TEST_PROMPT,
+        providerOptions: {
+          zhipu: { reasoning_effort: "minimal" },
+        },
+      });
+
+    const calls =
+      server.urls["https://open.bigmodel.cn/api/paas/v4/chat/completions"]
+        .calls;
+    const body = calls[calls.length - 1].requestBodyJson as ZhipuRequestBody;
+    expect(body.reasoning_effort).toBe("minimal");
+  });
+
+  it.each(["glm-5.1", "glm-5", "glm-4.7-flash"])(
+    "should warn when reasoning effort is used with %s",
+    async (modelId) => {
+      prepareJsonResponse({ content: "" });
+
+      const result = await provider
+        .chat(modelId, { reasoningEffort: "high" })
+        .doGenerate({ prompt: TEST_PROMPT });
+
+      expect(result.warnings).toContainEqual({
+        type: "other",
+        message: `reasoning_effort is not supported by model "${modelId}" and will likely be ignored by the upstream API.`,
+      });
+    },
+  );
+
+  it("should warn when providerOptions set reasoningEffort for an unsupported model", async () => {
+    prepareJsonResponse({ content: "" });
+
+    const result = await provider.chat("glm-5.1").doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        zhipu: { reasoningEffort: "high" },
+      },
+    });
+
+    expect(result.warnings).toContainEqual({
+      type: "other",
+      message:
+        'reasoning_effort is not supported by model "glm-5.1" and will likely be ignored by the upstream API.',
+    });
+  });
+
+  it.each(["glm-5.2", "glm-5.3", "glm-next"])(
+    "should not warn for supported or unrecognized future model %s",
+    async (modelId) => {
+      prepareJsonResponse({ content: "" });
+
+      const result = await provider
+        .chat(modelId, { reasoningEffort: "high" })
+        .doGenerate({ prompt: TEST_PROMPT });
+
+      expect(result.warnings).not.toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining("reasoning_effort is not supported"),
+        }),
+      );
+    },
+  );
+
+  it("should not warn when reasoning effort is omitted", async () => {
+    prepareJsonResponse({ content: "" });
+
+    const result = await provider.chat("glm-5.1").doGenerate({
+      prompt: TEST_PROMPT,
+    });
+
+    expect(result.warnings).not.toContainEqual(
+      expect.objectContaining({
+        message: expect.stringContaining("reasoning_effort is not supported"),
+      }),
+    );
+  });
 });
 
 describe("doStream", () => {
@@ -384,5 +510,29 @@ describe("doStream", () => {
         },
       ]),
     );
+  });
+
+  it("should map reasoningEffort in streaming requests", async () => {
+    server.urls[
+      "https://open.bigmodel.cn/api/paas/v4/chat/completions"
+    ].response = {
+      type: "stream-chunks",
+      chunks: ["data: [DONE]\\n\\n"],
+    };
+
+    await provider.chat("glm-5.2").doStream({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        zhipu: { reasoningEffort: "high" },
+      },
+    });
+
+    const calls =
+      server.urls["https://open.bigmodel.cn/api/paas/v4/chat/completions"]
+        .calls;
+    const body = calls[calls.length - 1].requestBodyJson as ZhipuRequestBody;
+    expect(body.reasoning_effort).toBe("high");
+    expect(body.stream).toBe(true);
+    expect(body).not.toHaveProperty("reasoningEffort");
   });
 });

--- a/src/zhipu-chat-language-model.ts
+++ b/src/zhipu-chat-language-model.ts
@@ -73,6 +73,75 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
     return { type: "unsupported", feature, details };
   }
 
+  private getZhipuProviderOptions(
+    providerOptions: unknown,
+  ): Record<string, unknown> {
+    if (providerOptions == null || typeof providerOptions !== "object") {
+      return {};
+    }
+
+    const zhipuOptions = (providerOptions as Record<string, unknown>).zhipu;
+
+    return zhipuOptions != null &&
+      typeof zhipuOptions === "object" &&
+      !Array.isArray(zhipuOptions)
+      ? (zhipuOptions as Record<string, unknown>)
+      : {};
+  }
+
+  private getReasoningEffort(zhipuOptions: Record<string, unknown>) {
+    return (
+      zhipuOptions.reasoningEffort ??
+      zhipuOptions.reasoning_effort ??
+      this.settings.reasoningEffort
+    );
+  }
+
+  private isReasoningEffortUnsupportedModel(): boolean {
+    const match = /^glm-(\d+)(?:\.(\d+))?(?:[-_].*)?$/i.exec(this.modelId);
+
+    if (match == null) {
+      return false;
+    }
+
+    const major = Number(match[1]);
+    const minor = Number(match[2] ?? 0);
+
+    return major < 5 || (major === 5 && minor < 2);
+  }
+
+  private addReasoningEffortWarning(
+    warnings: SharedV3Warning[],
+    reasoningEffort: unknown,
+  ): void {
+    if (
+      reasoningEffort !== undefined &&
+      this.isReasoningEffortUnsupportedModel()
+    ) {
+      warnings.push({
+        type: "other",
+        message: `reasoning_effort is not supported by model "${this.modelId}" and will likely be ignored by the upstream API.`,
+      });
+    }
+  }
+
+  private applyZhipuProviderOptions<T extends object>(
+    args: T,
+    zhipuOptions: Record<string, unknown>,
+    reasoningEffort: unknown,
+  ) {
+    const rawZhipuOptions = { ...zhipuOptions };
+    delete rawZhipuOptions.reasoningEffort;
+
+    return {
+      ...args,
+      ...rawZhipuOptions,
+      ...(reasoningEffort !== undefined && {
+        reasoning_effort: reasoningEffort,
+      }),
+    };
+  }
+
   private getArgs({
     prompt,
     maxOutputTokens,
@@ -283,9 +352,14 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
     options: Parameters<LanguageModelV3["doGenerate"]>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV3["doGenerate"]>>> {
     const { args, warnings } = this.getArgs(options);
-    const providerOptions = options.providerOptions || {};
-    const zhipuOptions = providerOptions.zhipu || {};
-    const fullArgs = { ...args, ...zhipuOptions };
+    const zhipuOptions = this.getZhipuProviderOptions(options.providerOptions);
+    const reasoningEffort = this.getReasoningEffort(zhipuOptions);
+    this.addReasoningEffortWarning(warnings, reasoningEffort);
+    const fullArgs = this.applyZhipuProviderOptions(
+      args,
+      zhipuOptions,
+      reasoningEffort,
+    );
 
     const {
       value: response,
@@ -370,9 +444,13 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
     options: Parameters<LanguageModelV3["doStream"]>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV3["doStream"]>>> {
     const { args, warnings } = this.getArgs(options);
-    const providerOptions = options.providerOptions || {};
-    const zhipuOptions = providerOptions.zhipu || {};
-    const body = { ...args, ...zhipuOptions, stream: true };
+    const zhipuOptions = this.getZhipuProviderOptions(options.providerOptions);
+    const reasoningEffort = this.getReasoningEffort(zhipuOptions);
+    this.addReasoningEffortWarning(warnings, reasoningEffort);
+    const body = {
+      ...this.applyZhipuProviderOptions(args, zhipuOptions, reasoningEffort),
+      stream: true,
+    };
 
     const { responseHeaders, value: response } = await postJsonToApi({
       url: `${this.config.baseURL}/chat/completions`,

--- a/src/zhipu-chat-language-model.ts
+++ b/src/zhipu-chat-language-model.ts
@@ -98,7 +98,9 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
   }
 
   private isReasoningEffortUnsupportedModel(): boolean {
-    const match = /^glm-(\d+)(?:\.(\d+))?(?:[-_].*)?$/i.exec(this.modelId);
+    const match = /^glm-(\d+)(?:\.(\d+))?[a-z]*(?:[-_].*)?$/i.exec(
+      this.modelId,
+    );
 
     if (match == null) {
       return false;

--- a/src/zhipu-chat-settings.ts
+++ b/src/zhipu-chat-settings.ts
@@ -1,6 +1,7 @@
 // https://bigmodel.cn/dev/howuse/model
 export type ZhipuChatModelId =
   // Language models
+  | "glm-5.2"
   | "glm-5.1"
   | "glm-5"
   | "glm-5-turbo"
@@ -25,6 +26,20 @@ export type ZhipuChatModelId =
   | "glm-4.1v-thinking-flash"
   | "glm-4.1v-thinking-flashx"
   | (string & {});
+
+/**
+ * Controls the amount of reasoning GLM-5.2+ applies to a request.
+ *
+ * @see https://docs.z.ai/guides/capabilities/thinking
+ */
+export type ZhipuReasoningEffort =
+  | "max"
+  | "xhigh"
+  | "high"
+  | "medium"
+  | "low"
+  | "minimal"
+  | "none";
 
 /**
  * Thinking mode configuration for GLM-4.5+ models.
@@ -68,4 +83,13 @@ export interface ZhipuChatSettings {
    * @see https://docs.z.ai/guides/llm/glm-4.7
    */
   thinking?: ZhipuThinkingConfig;
+  /**
+   * Controls the reasoning effort for GLM-5.2+ models.
+   *
+   * This does not enable thinking automatically. Set `thinking.type` to
+   * `"enabled"` when deep thinking is required.
+   *
+   * @see https://docs.z.ai/guides/capabilities/thinking
+   */
+  reasoningEffort?: ZhipuReasoningEffort;
 }


### PR DESCRIPTION
## Summary

- expose GLM-5.2+ `reasoningEffort` through model settings and `providerOptions.zhipu`
- map the camel-case option to Z.ai's `reasoning_effort` request field for standard and streaming requests
- warn when a recognized GLM-5.1-or-earlier model is likely to ignore the setting
- add documentation, exported types, and a runnable GLM-5.2 example

## Validation

- TypeScript type check
- ESLint
- Node tests (33 passing)
- Edge tests (33 passing)

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring reasoning effort levels for GLM-5.2+ models.
  * Added support for the `glm-5.2` model and reasoning-effort configuration types.
  * Reasoning effort is supported for both text generation and streaming requests.
  * Added a runnable example that displays generated text and reasoning separately.
* **Documentation**
  * Documented configuration options, supported values, compatibility warnings, and example commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->