### PR TITLE
feat: migrate provider to V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zhipu AI Provider - Vercel AI SDK Community Provider
 
-This is a [Zhipu](https://www.zhipuai.cn/) (Z.ai) provider for the [Vercel AI SDK](https://ai-sdk.dev/). It supports AI SDK 6 and the `LanguageModelV3` custom-provider contract for language models, plus embedding and image models provided on [bigmodel.cn](https://bigmodel.cn/) or [z.ai](https://docs.z.ai/) by [ZhipuAI](https://www.zhipuai.cn/).
+This is a [Zhipu](https://www.zhipuai.cn/) (Z.ai) provider for the [Vercel AI SDK](https://ai-sdk.dev/). It supports AI SDK 7 and the `ProviderV4` custom-provider contract, including `LanguageModelV4`, `EmbeddingModelV4`, and `ImageModelV4`, for models provided on [bigmodel.cn](https://bigmodel.cn/) or [z.ai](https://docs.z.ai/) by [ZhipuAI](https://www.zhipuai.cn/).
 
 ## Setup
 
@@ -113,6 +113,9 @@ const { text } = await generateText({
   },
 });
 ```
+
+The AI SDK 7 `reasoning` call option is also forwarded as `reasoning_effort`
+unless a Zhipu-specific `reasoningEffort` option is provided.
 
 The provider forwards `reasoningEffort` for any model ID, so future Z.ai
 models do not require a provider update. It warns, without blocking the

--- a/examples/stream-text.mjs
+++ b/examples/stream-text.mjs
@@ -11,7 +11,7 @@ const provider = getProvider();
 
 const result = streamText({
   model: provider.chat(models.text),
-  prompt: "Write a short release note for migrating a custom AI SDK provider to LanguageModelV3.",
+  prompt: "Write a short release note for migrating a custom AI SDK provider to LanguageModelV4.",
 });
 
 section("Stream");

--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
     }
   },
   "dependencies": {
-    "@ai-sdk/provider": "^3.0.3",
-    "@ai-sdk/provider-utils": "^4.0.6"
+    "@ai-sdk/provider": "^4.0.3",
+    "@ai-sdk/provider-utils": "^5.0.12"
   },
   "devDependencies": {
     "@edge-runtime/vm": "^5.0.0",
     "@eslint/js": "^9.21.0",
     "@types/node": "^18",
-    "ai": "^6.0.35",
+    "ai": "^7.0.37",
     "eslint": "^9.21.0",
     "msw": "2.7.0",
     "tsup": "^8",
@@ -58,7 +58,7 @@
     "zod": "4.3.5"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@ai-sdk/provider':
-        specifier: ^3.0.3
-        version: 3.0.3
+        specifier: ^4.0.3
+        version: 4.0.3
       '@ai-sdk/provider-utils':
-        specifier: ^4.0.6
-        version: 4.0.6(zod@4.3.5)
+        specifier: ^5.0.12
+        version: 5.0.12(zod@4.3.5)
     devDependencies:
       '@edge-runtime/vm':
         specifier: ^5.0.0
@@ -25,8 +25,8 @@ importers:
         specifier: ^18
         version: 18.19.79
       ai:
-        specifier: ^6.0.35
-        version: 6.0.35(zod@4.3.5)
+        specifier: ^7.0.37
+        version: 7.0.37(zod@4.3.5)
       eslint:
         specifier: ^9.21.0
         version: 9.21.0
@@ -51,21 +51,21 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@3.0.14':
-    resolution: {integrity: sha512-udVpkDaQ00jMcBvtGGvmkEBU31XidsHB4E8HIF9l7/H7lyjOS/EtXzN2adoupDg5j1/VjjSI3Ny5P1zHUvLyMA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.28':
+    resolution: {integrity: sha512-ee9TsNO3mkgHDWmTmJ8Fvltr6PFh52zhrV2+FaKJY3F3iu7kWZi5tCRJCR1HVhhlpj6lHniUb28nLQdPHkA/1Q==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.6':
-    resolution: {integrity: sha512-o/SP1GQOrpXAzHjMosPHI0Pu+YkwxIMndSjSLrEXtcVixdrjqrGaA9I7xJcWf+XpRFJ9byPHrKYnprwS+36gMg==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.12':
+    resolution: {integrity: sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.3':
-    resolution: {integrity: sha512-qGPYdoAuECaUXPrrz0BPX1SacZQuJ6zky0aakxpW89QW1hrY0eF4gcFm/3L9Pk8C5Fwe+RvBf2z7ZjDhaPjnlg==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
 
   '@bundled-es-modules/cookie@2.0.1':
     resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
@@ -370,10 +370,6 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
-
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -412,51 +408,61 @@ packages:
     resolution: {integrity: sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.9':
     resolution: {integrity: sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.34.9':
     resolution: {integrity: sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.34.9':
     resolution: {integrity: sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.9':
     resolution: {integrity: sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.9':
     resolution: {integrity: sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.9':
     resolution: {integrity: sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.34.9':
     resolution: {integrity: sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.34.9':
     resolution: {integrity: sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.34.9':
     resolution: {integrity: sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.34.9':
     resolution: {integrity: sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==}
@@ -541,8 +547,8 @@ packages:
     resolution: {integrity: sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
   '@vitest/expect@3.0.7':
@@ -574,6 +580,9 @@ packages:
   '@vitest/utils@3.0.7':
     resolution: {integrity: sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -584,9 +593,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@6.0.35:
-    resolution: {integrity: sha512-MxgtU6CjnegH1rhRfomM0gptKxP6r+9sxbLvYq36C1l85+o0LacqbXLdNVYzqab+lHN4q7ZP3QS8wZq4YkZahA==}
-    engines: {node: '>=18'}
+  ai@7.0.37:
+    resolution: {integrity: sha512-stF+SEQJgKY3Qfe3FwNzqUrehHviOp2l7LemoI8YMOa0Zk5PxKsRNgUk3cHXz0RAue9RRyCAis2fz6LSCP6EKw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -782,8 +791,8 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   expect-type@1.2.0:
@@ -1455,21 +1464,22 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.14(zod@4.3.5)':
+  '@ai-sdk/gateway@4.0.28(zod@4.3.5)':
     dependencies:
-      '@ai-sdk/provider': 3.0.3
-      '@ai-sdk/provider-utils': 4.0.6(zod@4.3.5)
-      '@vercel/oidc': 3.1.0
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.3.5)
+      '@vercel/oidc': 3.2.0
       zod: 4.3.5
 
-  '@ai-sdk/provider-utils@4.0.6(zod@4.3.5)':
+  '@ai-sdk/provider-utils@5.0.12(zod@4.3.5)':
     dependencies:
-      '@ai-sdk/provider': 3.0.3
+      '@ai-sdk/provider': 4.0.3
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
       zod: 4.3.5
 
-  '@ai-sdk/provider@3.0.3':
+  '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -1706,8 +1716,6 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opentelemetry/api@1.9.0': {}
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -1861,7 +1869,7 @@ snapshots:
       '@typescript-eslint/types': 8.26.0
       eslint-visitor-keys: 4.2.0
 
-  '@vercel/oidc@3.1.0': {}
+  '@vercel/oidc@3.2.0': {}
 
   '@vitest/expect@3.0.7':
     dependencies:
@@ -1904,18 +1912,19 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  '@workflow/serde@4.1.0': {}
+
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
 
   acorn@8.14.0: {}
 
-  ai@6.0.35(zod@4.3.5):
+  ai@7.0.37(zod@4.3.5):
     dependencies:
-      '@ai-sdk/gateway': 3.0.14(zod@4.3.5)
-      '@ai-sdk/provider': 3.0.3
-      '@ai-sdk/provider-utils': 4.0.6(zod@4.3.5)
-      '@opentelemetry/api': 1.9.0
+      '@ai-sdk/gateway': 4.0.28(zod@4.3.5)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.3.5)
       zod: 4.3.5
 
   ajv@6.12.6:
@@ -2130,7 +2139,7 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  eventsource-parser@3.0.6: {}
+  eventsource-parser@3.1.0: {}
 
   expect-type@1.2.0: {}
 

--- a/src/convert-to-zhipu-chat-messages.test.ts
+++ b/src/convert-to-zhipu-chat-messages.test.ts
@@ -10,7 +10,7 @@ describe("user messages", () => {
           { type: "text", text: "Hello" },
           {
             type: "file",
-            data: new Uint8Array([0, 1, 2, 3]),
+            data: { type: "data", data: new Uint8Array([0, 1, 2, 3]) },
             mediaType: "image/png",
           },
         ],
@@ -69,5 +69,40 @@ describe("assistant messages", () => {
     ]);
 
     expect(result).toMatchSnapshot();
+  });
+
+  it("should reject unsupported V4 assistant content parts", () => {
+    expect(() =>
+      convertToZhipuChatMessages([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "custom",
+              kind: "zhipu.thinking",
+            },
+          ],
+        },
+      ]),
+    ).toThrow("Assistant custom content parts");
+  });
+});
+
+describe("tool messages", () => {
+  it("should reject unsupported V4 tool approval responses", () => {
+    expect(() =>
+      convertToZhipuChatMessages([
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-approval-response",
+              approvalId: "approval-1",
+              approved: true,
+            },
+          ],
+        },
+      ]),
+    ).toThrow("Tool approval response content parts");
   });
 });

--- a/src/convert-to-zhipu-chat-messages.ts
+++ b/src/convert-to-zhipu-chat-messages.ts
@@ -1,12 +1,12 @@
 import {
-  LanguageModelV3Prompt,
+  LanguageModelV4Prompt,
   UnsupportedFunctionalityError,
 } from "@ai-sdk/provider";
 import { convertUint8ArrayToBase64 } from "@ai-sdk/provider-utils";
 import { ZhipuPrompt } from "./zhipu-chat-prompt";
 
 export function convertToZhipuChatMessages(
-  prompt: LanguageModelV3Prompt,
+  prompt: LanguageModelV4Prompt,
 ): ZhipuPrompt {
   const messages: ZhipuPrompt = [];
 
@@ -42,28 +42,31 @@ export function convertToZhipuChatMessages(
                 return { type: "text", text: part.text };
               }
               case "file": {
-                if (part.mediaType.startsWith("image/")) {
+                if (
+                  part.mediaType.startsWith("image/") &&
+                  (part.data.type === "data" || part.data.type === "url")
+                ) {
                   return {
                     type: "image_url",
                     image_url: {
                       url:
-                        part.data instanceof URL
-                          ? part.data.toString()
-                          : typeof part.data === "string"
-                            ? part.data
-                            : `data:${part.mediaType};base64,${convertUint8ArrayToBase64(part.data)}`,
+                        part.data.type === "url"
+                          ? part.data.url.toString()
+                          : typeof part.data.data === "string"
+                            ? `data:${part.mediaType};base64,${part.data.data}`
+                            : `data:${part.mediaType};base64,${convertUint8ArrayToBase64(part.data.data)}`,
                     },
                   };
                 }
 
                 if (
                   part.mediaType.startsWith("video/") &&
-                  part.data instanceof URL
+                  part.data.type === "url"
                 ) {
                   return {
                     type: "video_url",
                     video_url: {
-                      url: part.data.toString(),
+                      url: part.data.url.toString(),
                     },
                   };
                 }
@@ -97,6 +100,12 @@ export function convertToZhipuChatMessages(
             case "tool-result": {
               break;
             }
+            case "reasoning-file":
+            case "custom": {
+              throw new UnsupportedFunctionalityError({
+                functionality: `Assistant ${part.type} content parts`,
+              });
+            }
             case "tool-call": {
               toolCalls.push({
                 id: part.toolCallId,
@@ -126,8 +135,10 @@ export function convertToZhipuChatMessages(
 
       case "tool": {
         for (const toolResponse of content) {
-          if (toolResponse.type !== "tool-result") {
-            continue;
+          if (toolResponse.type === "tool-approval-response") {
+            throw new UnsupportedFunctionalityError({
+              functionality: "Tool approval response content parts",
+            });
           }
 
           const output = toolResponse.output;

--- a/src/map-zhipu-finish-reason.ts
+++ b/src/map-zhipu-finish-reason.ts
@@ -1,8 +1,8 @@
-import { LanguageModelV3FinishReason } from "@ai-sdk/provider";
+import { LanguageModelV4FinishReason } from "@ai-sdk/provider";
 
 export function mapZhipuFinishReason(
   finishReason: string | null | undefined,
-): LanguageModelV3FinishReason {
+): LanguageModelV4FinishReason {
   switch (finishReason) {
     case "stop":
       return { unified: "stop", raw: finishReason };

--- a/src/zhipu-chat-language-model.test.ts
+++ b/src/zhipu-chat-language-model.test.ts
@@ -97,7 +97,7 @@ describe("doGenerate", () => {
     };
   }
 
-  it("should expose text content and V3 finish/usage shapes", async () => {
+  it("should expose text content and V4 finish/usage shapes", async () => {
     prepareJsonResponse({ content: "Hello, World!" });
 
     const result = await model.doGenerate({
@@ -209,7 +209,7 @@ describe("doGenerate", () => {
     });
   });
 
-  it("should map unsupported settings to V3 warnings", async () => {
+  it("should map unsupported settings to V4 warnings", async () => {
     prepareJsonResponse({ content: "" });
 
     const result = await model.doGenerate({
@@ -254,7 +254,10 @@ describe("doGenerate", () => {
             { type: "text", text: "Describe this image" },
             {
               type: "file",
-              data: new URL("https://example.com/image.png"),
+              data: {
+                type: "url",
+                url: new URL("https://example.com/image.png"),
+              },
               mediaType: "image/png",
             },
           ],
@@ -293,6 +296,36 @@ describe("doGenerate", () => {
     expect(body.temperature).toBe(0.8);
   });
 
+  it("should map the V4 reasoning option to the API request", async () => {
+    prepareJsonResponse({ content: "" });
+
+    await provider.chat("glm-5.2").doGenerate({
+      prompt: TEST_PROMPT,
+      reasoning: "high",
+    });
+
+    const calls =
+      server.urls["https://open.bigmodel.cn/api/paas/v4/chat/completions"]
+        .calls;
+    const body = calls[calls.length - 1].requestBodyJson as ZhipuRequestBody;
+    expect(body.reasoning_effort).toBe("high");
+  });
+
+  it("should let the V4 reasoning option override model settings", async () => {
+    prepareJsonResponse({ content: "" });
+
+    await provider.chat("glm-5.2", { reasoningEffort: "low" }).doGenerate({
+      prompt: TEST_PROMPT,
+      reasoning: "high",
+    });
+
+    const calls =
+      server.urls["https://open.bigmodel.cn/api/paas/v4/chat/completions"]
+        .calls;
+    const body = calls[calls.length - 1].requestBodyJson as ZhipuRequestBody;
+    expect(body.reasoning_effort).toBe("high");
+  });
+
   it.each([
     "max",
     "xhigh",
@@ -301,31 +334,32 @@ describe("doGenerate", () => {
     "low",
     "minimal",
     "none",
-  ] as const)("should map %s reasoning effort to the API request", async (reasoningEffort) => {
-    prepareJsonResponse({ content: "" });
+  ] as const)(
+    "should map %s reasoning effort to the API request",
+    async (reasoningEffort) => {
+      prepareJsonResponse({ content: "" });
 
-    await provider
-      .chat("glm-5.2", { reasoningEffort })
-      .doGenerate({ prompt: TEST_PROMPT });
+      await provider
+        .chat("glm-5.2", { reasoningEffort })
+        .doGenerate({ prompt: TEST_PROMPT });
 
-    const calls =
-      server.urls["https://open.bigmodel.cn/api/paas/v4/chat/completions"]
-        .calls;
-    const body = calls[calls.length - 1].requestBodyJson as ZhipuRequestBody;
-    expect(body.reasoning_effort).toBe(reasoningEffort);
-  });
+      const calls =
+        server.urls["https://open.bigmodel.cn/api/paas/v4/chat/completions"]
+          .calls;
+      const body = calls[calls.length - 1].requestBodyJson as ZhipuRequestBody;
+      expect(body.reasoning_effort).toBe(reasoningEffort);
+    },
+  );
 
   it("should prefer request-level reasoningEffort and omit its camel-case form", async () => {
     prepareJsonResponse({ content: "" });
 
-    await provider
-      .chat("glm-5.2", { reasoningEffort: "low" })
-      .doGenerate({
-        prompt: TEST_PROMPT,
-        providerOptions: {
-          zhipu: { reasoningEffort: "high" },
-        },
-      });
+    await provider.chat("glm-5.2", { reasoningEffort: "low" }).doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        zhipu: { reasoningEffort: "high" },
+      },
+    });
 
     const calls =
       server.urls["https://open.bigmodel.cn/api/paas/v4/chat/completions"]
@@ -338,14 +372,12 @@ describe("doGenerate", () => {
   it("should preserve raw reasoning_effort provider-option passthrough", async () => {
     prepareJsonResponse({ content: "" });
 
-    await provider
-      .chat("glm-5.2", { reasoningEffort: "low" })
-      .doGenerate({
-        prompt: TEST_PROMPT,
-        providerOptions: {
-          zhipu: { reasoning_effort: "minimal" },
-        },
-      });
+    await provider.chat("glm-5.2", { reasoningEffort: "low" }).doGenerate({
+      prompt: TEST_PROMPT,
+      providerOptions: {
+        zhipu: { reasoning_effort: "minimal" },
+      },
+    });
 
     const calls =
       server.urls["https://open.bigmodel.cn/api/paas/v4/chat/completions"]
@@ -420,7 +452,7 @@ describe("doGenerate", () => {
 });
 
 describe("doStream", () => {
-  it("should stream V3 events", async () => {
+  it("should stream V4 events", async () => {
     server.urls[
       "https://open.bigmodel.cn/api/paas/v4/chat/completions"
     ].response = {

--- a/src/zhipu-chat-language-model.ts
+++ b/src/zhipu-chat-language-model.ts
@@ -1,11 +1,11 @@
 import {
   InvalidResponseDataError,
-  LanguageModelV3,
-  LanguageModelV3Content,
-  LanguageModelV3FinishReason,
-  LanguageModelV3StreamPart,
-  LanguageModelV3Usage,
-  SharedV3Warning,
+  LanguageModelV4,
+  LanguageModelV4Content,
+  LanguageModelV4FinishReason,
+  LanguageModelV4StreamPart,
+  LanguageModelV4Usage,
+  SharedV4Warning,
 } from "@ai-sdk/provider";
 import {
   combineHeaders,
@@ -35,8 +35,8 @@ type ZhipuChatConfig = {
 
 type ZhipuWebSearchResult = z.infer<typeof zhipuWebSearchItemSchema>;
 
-export class ZhipuChatLanguageModel implements LanguageModelV3 {
-  readonly specificationVersion = "v3" as const;
+export class ZhipuChatLanguageModel implements LanguageModelV4 {
+  readonly specificationVersion = "v4" as const;
   readonly supportedUrls: Record<string, RegExp[]> = {
     "image/*": [/^data:image\/[a-zA-Z]+;base64,/, /^https?:\/\/.+$/i],
     "video/*": [/^https?:\/\/.+\.(mp4|webm|ogg)$/i],
@@ -69,7 +69,7 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
   private unsupported(
     feature: string,
     details?: string,
-  ): Extract<SharedV3Warning, { type: "unsupported" }> {
+  ): Extract<SharedV4Warning, { type: "unsupported" }> {
     return { type: "unsupported", feature, details };
   }
 
@@ -89,10 +89,14 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
       : {};
   }
 
-  private getReasoningEffort(zhipuOptions: Record<string, unknown>) {
+  private getReasoningEffort(
+    zhipuOptions: Record<string, unknown>,
+    reasoning: Parameters<LanguageModelV4["doGenerate"]>[0]["reasoning"],
+  ) {
     return (
       zhipuOptions.reasoningEffort ??
       zhipuOptions.reasoning_effort ??
+      (reasoning !== "provider-default" ? reasoning : undefined) ??
       this.settings.reasoningEffort
     );
   }
@@ -113,7 +117,7 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
   }
 
   private addReasoningEffortWarning(
-    warnings: SharedV3Warning[],
+    warnings: SharedV4Warning[],
     reasoningEffort: unknown,
   ): void {
     if (
@@ -157,8 +161,8 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
     seed,
     tools,
     toolChoice,
-  }: Parameters<LanguageModelV3["doGenerate"]>[0]) {
-    const warnings: SharedV3Warning[] = [];
+  }: Parameters<LanguageModelV4["doGenerate"]>[0]) {
+    const warnings: SharedV4Warning[] = [];
 
     if (
       !this.config.isMultiModel &&
@@ -301,7 +305,7 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
         }
       | null
       | undefined,
-  ): LanguageModelV3Usage {
+  ): LanguageModelV4Usage {
     return {
       inputTokens: {
         total: usage?.prompt_tokens,
@@ -326,7 +330,7 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
 
   private buildSourceContent(
     webSearch: ZhipuWebSearchResult[] | ZhipuWebSearchResult | null | undefined,
-  ): LanguageModelV3Content[] {
+  ): LanguageModelV4Content[] {
     const items =
       webSearch == null
         ? []
@@ -351,11 +355,14 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
   }
 
   async doGenerate(
-    options: Parameters<LanguageModelV3["doGenerate"]>[0],
-  ): Promise<Awaited<ReturnType<LanguageModelV3["doGenerate"]>>> {
+    options: Parameters<LanguageModelV4["doGenerate"]>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV4["doGenerate"]>>> {
     const { args, warnings } = this.getArgs(options);
     const zhipuOptions = this.getZhipuProviderOptions(options.providerOptions);
-    const reasoningEffort = this.getReasoningEffort(zhipuOptions);
+    const reasoningEffort = this.getReasoningEffort(
+      zhipuOptions,
+      options.reasoning,
+    );
     this.addReasoningEffortWarning(warnings, reasoningEffort);
     const fullArgs = this.applyZhipuProviderOptions(
       args,
@@ -381,7 +388,7 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
 
     const responseData = response as z.infer<typeof zhipuChatResponseSchema>;
     const choice = responseData.choices[0];
-    const content: LanguageModelV3Content[] = [];
+    const content: LanguageModelV4Content[] = [];
     const responseText = choice.message.content;
     const responseReasoningText = choice.message.reasoning_content;
 
@@ -443,11 +450,14 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
   }
 
   async doStream(
-    options: Parameters<LanguageModelV3["doStream"]>[0],
-  ): Promise<Awaited<ReturnType<LanguageModelV3["doStream"]>>> {
+    options: Parameters<LanguageModelV4["doStream"]>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV4["doStream"]>>> {
     const { args, warnings } = this.getArgs(options);
     const zhipuOptions = this.getZhipuProviderOptions(options.providerOptions);
-    const reasoningEffort = this.getReasoningEffort(zhipuOptions);
+    const reasoningEffort = this.getReasoningEffort(
+      zhipuOptions,
+      options.reasoning,
+    );
     this.addReasoningEffortWarning(warnings, reasoningEffort);
     const body = {
       ...this.applyZhipuProviderOptions(args, zhipuOptions, reasoningEffort),
@@ -472,11 +482,11 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
       hasFinished: boolean;
     }> = [];
 
-    let finishReason: LanguageModelV3FinishReason = {
+    let finishReason: LanguageModelV4FinishReason = {
       unified: "other",
       raw: undefined,
     };
-    let usage: LanguageModelV3Usage = this.mapUsage(undefined);
+    let usage: LanguageModelV4Usage = this.mapUsage(undefined);
     let isFirstChunk = true;
     let isActiveReasoning = false;
     let isActiveText = false;
@@ -485,7 +495,7 @@ export class ZhipuChatLanguageModel implements LanguageModelV3 {
       stream: response.pipeThrough(
         new TransformStream<
           ParseResult<z.infer<typeof zhipuChatChunkSchema>>,
-          LanguageModelV3StreamPart
+          LanguageModelV4StreamPart
         >({
           transform(chunk, controller) {
             if (options.includeRawChunks) {

--- a/src/zhipu-embedding-model.ts
+++ b/src/zhipu-embedding-model.ts
@@ -1,5 +1,5 @@
 import {
-  EmbeddingModelV3,
+  EmbeddingModelV4,
   TooManyEmbeddingValuesForCallError,
 } from "@ai-sdk/provider";
 import {
@@ -24,8 +24,8 @@ type ZhipuEmbeddingConfig = {
   fetch?: FetchFunction;
 };
 
-export class ZhipuEmbeddingModel implements EmbeddingModelV3 {
-  readonly specificationVersion = "v3" as const;
+export class ZhipuEmbeddingModel implements EmbeddingModelV4 {
+  readonly specificationVersion = "v4" as const;
   readonly modelId: ZhipuEmbeddingModelId;
 
   private readonly config: ZhipuEmbeddingConfig;
@@ -57,8 +57,8 @@ export class ZhipuEmbeddingModel implements EmbeddingModelV3 {
     values,
     abortSignal,
     headers,
-  }: Parameters<EmbeddingModelV3["doEmbed"]>[0]): Promise<
-    Awaited<ReturnType<EmbeddingModelV3["doEmbed"]>>
+  }: Parameters<EmbeddingModelV4["doEmbed"]>[0]): Promise<
+    Awaited<ReturnType<EmbeddingModelV4["doEmbed"]>>
   > {
     if (values.length > this.maxEmbeddingsPerCall) {
       throw new TooManyEmbeddingValuesForCallError({

--- a/src/zhipu-image-model.test.ts
+++ b/src/zhipu-image-model.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { FetchFunction } from "@ai-sdk/provider-utils";
+import { ZhipuImageModel } from "./zhipu-image-model";
+
+describe("ZhipuImageModel", () => {
+  it("should implement V4 calls and use the configured fetch for image downloads", async () => {
+    const fetch: FetchFunction = vi.fn(async (input: RequestInfo | URL) => {
+      if (input.toString().endsWith("/images/generations")) {
+        return Response.json({
+          created: 1,
+          data: [{ url: "https://images.example.com/generated.png" }],
+        });
+      }
+
+      return new Response(new Uint8Array([1, 2, 3]));
+    });
+    const model = new ZhipuImageModel("glm-image", {
+      provider: "zhipu.image",
+      url: ({ path }) => `https://api.example.com${path}`,
+      headers: () => ({ Authorization: "Bearer test-api-key" }),
+      fetch,
+      _internal: { currentDate: () => new Date(1) },
+    });
+
+    const result = await model.doGenerate({
+      prompt: "A yellow bird",
+      n: 1,
+      size: "1024x1024",
+      aspectRatio: undefined,
+      seed: undefined,
+      files: [
+        {
+          type: "file",
+          mediaType: "image/png",
+          data: new Uint8Array([0]),
+        },
+      ],
+      mask: {
+        type: "file",
+        mediaType: "image/png",
+        data: new Uint8Array([0]),
+      },
+      providerOptions: {},
+    });
+
+    expect(model.specificationVersion).toBe("v4");
+    expect(result.images).toStrictEqual([new Uint8Array([1, 2, 3])]);
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        { type: "unsupported", feature: "files" },
+        { type: "unsupported", feature: "mask" },
+      ]),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://images.example.com/generated.png",
+      expect.anything(),
+    );
+  });
+});

--- a/src/zhipu-image-model.ts
+++ b/src/zhipu-image-model.ts
@@ -1,4 +1,4 @@
-import { ImageModelV3 } from "@ai-sdk/provider";
+import { ImageModelV4 } from "@ai-sdk/provider";
 import {
   combineHeaders,
   createJsonErrorResponseHandler,
@@ -24,8 +24,8 @@ export type ZhipuImageModelConfig = {
   };
 };
 
-export class ZhipuImageModel implements ImageModelV3 {
-  readonly specificationVersion = "v3" as const;
+export class ZhipuImageModel implements ImageModelV4 {
+  readonly specificationVersion = "v4" as const;
   readonly maxImagesPerCall = 10;
 
   get provider(): string {
@@ -43,11 +43,13 @@ export class ZhipuImageModel implements ImageModelV3 {
     size,
     aspectRatio,
     seed,
+    files,
+    mask,
     providerOptions,
     headers,
     abortSignal,
-  }: Parameters<ImageModelV3["doGenerate"]>[0]): Promise<
-    Awaited<ReturnType<ImageModelV3["doGenerate"]>>
+  }: Parameters<ImageModelV4["doGenerate"]>[0]): Promise<
+    Awaited<ReturnType<ImageModelV4["doGenerate"]>>
   > {
     const warnings: Array<{
       type: "unsupported";
@@ -78,6 +80,14 @@ export class ZhipuImageModel implements ImageModelV3 {
 
     if (seed != null) {
       warnings.push({ type: "unsupported", feature: "seed" });
+    }
+
+    if (files != null && files.length > 0) {
+      warnings.push({ type: "unsupported", feature: "files" });
+    }
+
+    if (mask != null) {
+      warnings.push({ type: "unsupported", feature: "mask" });
     }
 
     if (
@@ -119,7 +129,9 @@ export class ZhipuImageModel implements ImageModelV3 {
 
     const images = await Promise.all(
       typedResponse.data.map(async (item) => {
-        const imageResponse = await fetch(item.url, { signal: abortSignal });
+        const imageResponse = await (this.config.fetch ?? fetch)(item.url, {
+          signal: abortSignal,
+        });
         const arrayBuffer = await imageResponse.arrayBuffer();
         return new Uint8Array(arrayBuffer);
       }),

--- a/src/zhipu-image-model.ts
+++ b/src/zhipu-image-model.ts
@@ -132,6 +132,12 @@ export class ZhipuImageModel implements ImageModelV4 {
         const imageResponse = await (this.config.fetch ?? fetch)(item.url, {
           signal: abortSignal,
         });
+        if (!imageResponse.ok) {
+          throw new Error(
+            `Failed to download generated image: ${imageResponse.status} ${imageResponse.statusText}`,
+          );
+        }
+        const arrayBuffer = await imageResponse.arrayBuffer();
         const arrayBuffer = await imageResponse.arrayBuffer();
         return new Uint8Array(arrayBuffer);
       }),

--- a/src/zhipu-provider.ts
+++ b/src/zhipu-provider.ts
@@ -1,8 +1,8 @@
 import {
-  EmbeddingModelV3,
-  ImageModelV3,
-  LanguageModelV3,
-  ProviderV3,
+  EmbeddingModelV4,
+  ImageModelV4,
+  LanguageModelV4,
+  ProviderV4,
 } from "@ai-sdk/provider";
 import {
   FetchFunction,
@@ -19,38 +19,38 @@ import {
 import { ZhipuImageModel } from "./zhipu-image-model";
 import { ZhipuImageModelId } from "./zhipu-image-options";
 
-export interface ZhipuProvider extends ProviderV3 {
-  (modelId: ZhipuChatModelId, settings?: ZhipuChatSettings): LanguageModelV3;
+export interface ZhipuProvider extends ProviderV4 {
+  (modelId: ZhipuChatModelId, settings?: ZhipuChatSettings): LanguageModelV4;
 
   languageModel(
     modelId: ZhipuChatModelId,
     settings?: ZhipuChatSettings,
-  ): LanguageModelV3;
+  ): LanguageModelV4;
 
   chat(
     modelId: ZhipuChatModelId,
     settings?: ZhipuChatSettings,
-  ): LanguageModelV3;
+  ): LanguageModelV4;
 
   /** @deprecated Use embedding or embeddingModel instead */
   textEmbeddingModel(
     modelId: ZhipuEmbeddingModelId,
     settings?: ZhipuEmbeddingSettings,
-  ): EmbeddingModelV3;
+  ): EmbeddingModelV4;
 
   embedding(
     modelId: ZhipuEmbeddingModelId,
     settings?: ZhipuEmbeddingSettings,
-  ): EmbeddingModelV3;
+  ): EmbeddingModelV4;
 
   embeddingModel(
     modelId: ZhipuEmbeddingModelId,
     settings?: ZhipuEmbeddingSettings,
-  ): EmbeddingModelV3;
+  ): EmbeddingModelV4;
 
-  image(modelId: ZhipuImageModelId): ImageModelV3;
+  image(modelId: ZhipuImageModelId): ImageModelV4;
 
-  imageModel(modelId: ZhipuImageModelId): ImageModelV3;
+  imageModel(modelId: ZhipuImageModelId): ImageModelV4;
 }
 
 export interface ZhipuProviderSettings {
@@ -120,7 +120,7 @@ export function createZhipu(
       return createChatModel(modelId, settings);
     } as unknown as ZhipuProvider,
     {
-      specificationVersion: "v3" as const,
+      specificationVersion: "v4" as const,
       languageModel: createChatModel,
       chat: createChatModel,
       /** @deprecated Use embedding or embeddingModel instead */


### PR DESCRIPTION
## Summary
- Migrates the provider factories and all language, embedding, and image model adapters to the AI SDK V4 contracts.
- Updates V4 prompt conversion, reasoning precedence, and unsupported input handling.
- Updates AI SDK dependencies and adds image-model V4 coverage.

## Validation
- pnpm type-check
- pnpm test
- pnpm build
- pnpm lint
- pnpm prettier-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded Zhipu integration to Vercel AI SDK 7 and the ProviderV4 contract.
  * Added support for V4 language, embedding, and image model interfaces.
  * Forwarded the SDK’s `reasoning` option as Zhipu’s `reasoning_effort`, with provider-specific overrides supported.
  * Added image downloads through configured fetch implementations.
  * Added warnings for unsupported image-generation options.

* **Documentation**
  * Updated setup and migration examples for AI SDK 7 and V4 models.

* **Chores**
  * Updated runtime requirements and development tooling versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->